### PR TITLE
Propose to reference geronimo microprofile instead of tomee to ease m…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ CDI support for Apache Tomcat 9+
 
 ## Microprofile CDI extensions
 
-CDI microprofile extensions as listed in: org.apache.tomee.microprofile.TomEEMicroProfileListener
+TIP: see https://geronimo.apache.org/microprofile/ for dependencies (all are setup free).
+
+For a specific tomcat based integration, you can have a look to Apache Tomee and org.apache.tomee.microprofile.TomEEMicroProfileListener.
 
 ### Configuration
 org.apache.geronimo.config:geronimo-config


### PR DESCRIPTION
…icroprofile bootstrap

Knowing which extension and which impl jar implements a microprofile spec is rarely enough, it misses the spec version (since breaking changes are common).
The extension class is also not that needed since it is transparent and does not need additional config until you wantr to do something specific - but the extension does not help, it is the configuration strictly speaking.
Therefore referencing the impl website looks more relevant than the impl details.